### PR TITLE
fix: install libyaml-dev along with iruby

### DIFF
--- a/packages.osdeps
+++ b/packages.osdeps
@@ -13,6 +13,7 @@ jupyter-ruby:
         - autoconf
         - pkg-config
         - libtool
+        - libyaml-dev
     gem:
         - cztop
         - iruby


### PR DESCRIPTION
Dependency chain: iruby > psych > libyaml-dev