### PR TITLE
fix: limit irb version to <1.15 to workaround bug w/ iruby

### DIFF
--- a/packages.osdeps
+++ b/packages.osdeps
@@ -18,8 +18,16 @@ jupyter-ruby:
         - cztop
         - iruby
         - erector
-        - name: irb
+    osdep:
+        - irb
 
+irb:
+    gem:
+    - name: irb
+      version: "< 1.15"
+    osdep:
+    - yaml
+ 
 daru:
   gem:
     - daru


### PR DESCRIPTION
IRuby team already pushed a fix to this (https://github.com/SciRuby/iruby/pull/364), but they havent create a release yet. So I am manually forcing irb version to the working one for now.